### PR TITLE
Collect artifacts into public/ and update scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "pnpm --filter @zenode/designer dev",
-    "build": "pnpm --recursive build",
-    "start": "pnpm build && npx http-server . -p 3000 -o playground/index.html"
+    "build": "pnpm --recursive build && node scripts/collect.js",
+    "start": "pnpm build && npx http-server public -p 3000"
   },
   "engines": {
     "pnpm": ">=8.0.0"

--- a/playground/index.html
+++ b/playground/index.html
@@ -1459,9 +1459,9 @@
     </div>
 
     <script type="module">
-        import * as Zenode from "../packages/designer/dist/index.js";
-        import * as Serializer from "../packages/serializer/dist/index.js";
-        import { testConfig as initialConfig } from "../packages/designer/dist/config/testConfig.js";
+        import * as Zenode from "./dist/designer/index.js";
+        import * as Serializer from "./dist/serializer/index.js";
+        import { testConfig as initialConfig } from "./dist/designer/config/testConfig.js";
 
         const d3 = Zenode.d3;
         window.Zenode = Zenode;

--- a/scripts/collect.js
+++ b/scripts/collect.js
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+
+const root = process.cwd();
+const publicDir = path.join(root, 'public');
+
+/**
+ * Robustly copies a directory and all its contents (recursive).
+ */
+function copyFolderSync(from, to) {
+    if (!fs.existsSync(from)) return;
+    if (!fs.existsSync(to)) fs.mkdirSync(to, { recursive: true });
+    
+    fs.readdirSync(from).forEach(element => {
+        const fromPath = path.join(from, element);
+        const toPath = path.join(to, element);
+        if (fs.lstatSync(fromPath).isDirectory()) {
+            copyFolderSync(fromPath, toPath);
+        } else {
+            fs.copyFileSync(fromPath, toPath);
+        }
+    });
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+console.log('[DEPLOY] Preparing clean public/ directory...');
+if (fs.existsSync(publicDir)) {
+  fs.rmSync(publicDir, { recursive: true, force: true });
+}
+ensureDir(publicDir);
+
+// 1. Copy Static Assets
+console.log('[DEPLOY] Copying Playground HTML/CSS...');
+fs.copyFileSync(path.join(root, 'playground/index.html'), path.join(publicDir, 'index.html'));
+if (fs.existsSync(path.join(root, 'playground/zenode.css'))) {
+  fs.copyFileSync(path.join(root, 'playground/zenode.css'), path.join(publicDir, 'zenode.css'));
+} else if (fs.existsSync(path.join(root, 'packages/designer/zenode.css'))) {
+  fs.copyFileSync(path.join(root, 'packages/designer/zenode.css'), path.join(publicDir, 'zenode.css'));
+}
+
+// 2. Copy Full Package Builds
+console.log('[DEPLOY] Syncing package bundles...');
+copyFolderSync(path.join(root, 'packages/designer/dist'), path.join(publicDir, 'dist/designer'));
+copyFolderSync(path.join(root, 'packages/serializer/dist'), path.join(publicDir, 'dist/serializer'));
+
+console.log('[DEPLOY] Done! All artifacts collected in public/');


### PR DESCRIPTION
Add scripts/collect.js to gather built package bundles and static assets into public/ (cleans/creates public/, copies playground index.html and CSS, and syncs packages/*/dist into public/dist). Update package.json: run the collector after pnpm build and change start to serve the public directory. Adjust playground/index.html imports to reference the bundled dist paths under the public site so the playground works from the collected artifacts.