### PR TITLE
Add @zenode/serializer package with formats & tests

### DIFF
--- a/LAYER2_SERIALIZER.md
+++ b/LAYER2_SERIALIZER.md
@@ -1,69 +1,169 @@
-# Zenode Serializer (Layer 2) — Scope & Responsibilities
+Zenode Serializer — Development Prompt
+Objective
 
-## Purpose
-Layer 2 is responsible for transforming Zenode JSON into other formats and back.
+Build a standalone, framework-agnostic serialization library that converts workflow data between multiple formats using Zenode JSON as the canonical data model.
 
----
+The library must work independently, while integrating seamlessly with the Zenode ecosystem.
 
-## ✅ Responsibilities
+Core Principle
 
-- Convert JSON → External formats
-- Convert External formats → JSON
+Zenode JSON (ZenodeDiagramState) is the single source of truth.
 
----
+All transformations must follow this pattern:
 
-## Supported Formats
+External Format → Zenode JSON → External Format
 
-- JSON (pass-through)
-- BPMN 2.0 XML
-- Mermaid
-- DOT
-- Custom DSL
+No direct format-to-format conversions should exist.
 
----
+Scope of the Serializer
 
-## API Design
+The serializer is responsible only for:
 
-```ts
-serializer.toBPMN(json)
-serializer.toMermaid(json)
-serializer.toDOT(json)
+Parsing external formats into Zenode JSON
+Emitting Zenode JSON into external formats
+Validating data integrity
 
-serializer.fromBPMN(xml)
-serializer.fromDSL(dsl)
-```
+It must not include:
 
----
+UI logic
+Rendering logic
+Execution/runtime behavior
+Canonical Data Model
 
-## Rules
+Use ZenodeDiagramState as the central schema.
 
-- No rendering logic
-- No D3
-- No DOM
-- Pure transformation layer
+Requirements:
 
----
+Must include versioning (e.g. "1.0")
+Must support nodes, edges, and metadata
+Nodes must support meta: Record<string, any> for extensibility
+Structure must be stable and version-aware
 
-## Input
+The serializer must treat this format as authoritative.
 
-Zenode JSON:
-```json
-{
-  "nodes": [],
-  "edges": []
-}
-```
+Architecture
 
----
+Organize the package with clear separation of concerns:
 
-## Output
+packages/serializer/src/
+  ├── formats/
+  │    ├── json.ts
+  │    ├── mermaid.ts
+  │    ├── bpmn.ts
+  │    └── index.ts
+  ├── core/
+  │    ├── parser.ts
+  │    ├── emitter.ts
+  │    ├── validator.ts
+  │    └── registry.ts
+  ├── utils/
+  │    ├── graph.ts
+  │    ├── guards.ts
+  │    └── ids.ts
+  └── index.ts
 
-- XML / String / DSL formats
+Each format must be isolated and independently testable.
 
----
+Public API Design
 
-## ❌ Not Allowed
+Expose a simple and predictable API:
 
-- UI rendering
-- Workflow execution
-- Canvas logic
+serialize(input, { from: 'json', to: 'mermaid' })
+deserialize(input, { from: 'mermaid', to: 'json' })
+
+OR explicit helpers:
+
+toMermaid(json)
+fromMermaid(mermaid)
+
+toBPMN(json)
+fromBPMN(xml)
+
+Avoid over-generalization in early versions.
+
+Validation Requirements
+
+Implement strict validation for Zenode JSON:
+
+Required fields must exist
+Node and edge structure must be valid
+All referenced node IDs must exist
+No broken or dangling connections
+
+Validation must run before any transformation.
+
+Invalid input should return structured errors, not silent failures.
+
+Metadata Handling
+
+Nodes and edges may contain meta: Record<string, any>.
+
+Rules:
+
+Metadata must be preserved during transformations
+Do not modify metadata unless explicitly required by a format
+Unknown metadata should pass through untouched
+Mermaid Serializer (First Target)
+
+Implement Mermaid as the first external format.
+
+Responsibilities:
+
+Convert Zenode nodes and edges into valid Mermaid flowchart syntax
+Support basic node types and labels
+Handle directional connections
+Ensure output is readable and deterministic
+
+Do not aim for full feature parity initially. Focus on correctness and clarity.
+
+Testing Strategy
+
+Set up a full test suite using Vitest.
+
+Required tests:
+
+Validation tests
+Valid input passes
+Invalid input fails with clear errors
+Transformation tests
+Zenode JSON → Mermaid produces expected output
+Round-trip tests
+JSON → Mermaid → JSON should preserve structure as much as possible
+Edge cases
+Empty graphs
+Single node
+Cyclic graphs
+
+Tests must be deterministic and prevent regressions.
+
+Versioning Strategy
+
+Respect the version field in Zenode JSON.
+
+The serializer must:
+
+Validate supported versions
+Be forward-compatible where possible
+Allow future migration logic to be added cleanly
+Constraints
+Do not couple serializer logic with the designer
+Do not introduce execution logic
+Do not assume UI-specific properties
+Keep functions pure and deterministic
+Expected Outcome
+
+The serializer should:
+
+Convert between formats reliably
+Be usable as a standalone library
+Serve as the foundation for future layers (runtime, transformer)
+Maintain data integrity across transformations
+Success Criteria
+
+The implementation is complete when:
+
+Zenode JSON schema is validated and stable
+Mermaid export works reliably
+Round-trip tests pass
+API is simple and predictable
+No coupling exists with UI or runtime laye

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -140,6 +140,9 @@ export interface EdgeConfig {
   targetNodeId: string;
   targetPortId: string;
   type?: string;             // 'straight', 'curved', 's-shaped', 'l-bent'
+  waypoints?: { x: number; y: number }[]; // absolute coordinates
+  dashed?: boolean;
+  animated?: boolean;
   meta?: Record<string, any>;
 }
 

--- a/packages/designer/src/core/engine.ts
+++ b/packages/designer/src/core/engine.ts
@@ -984,16 +984,28 @@ export class ZenodeEngine {
   /**
    * Returns a specific connection's state.
    */
-  public getEdge(id: string): EdgeData | null {
+  public getEdge(id: string): import("@zenode/core").EdgeData | null {
     const edge = this.connections.find(c => c.id === id);
-    return edge ? { ...edge } as EdgeData : null;
+    if (!edge) return null;
+    
+    return {
+      ...edge,
+      waypoints: this.calculateEdgeWaypoints(edge),
+      dashed: !!edge.dashed,
+      animated: !!edge.animated
+    } as import("@zenode/core").EdgeData;
   }
 
   /**
    * Returns all connections on the canvas.
    */
-  public getAllEdges(): EdgeData[] {
-    return this.connections.map(c => ({ ...c } as EdgeData));
+  public getAllEdges(): import("@zenode/core").EdgeData[] {
+    return this.connections.map(c => ({
+      ...c,
+      waypoints: this.calculateEdgeWaypoints(c),
+      dashed: !!c.dashed,
+      animated: !!c.animated
+    } as import("@zenode/core").EdgeData));
   }
 
   /**
@@ -2484,6 +2496,44 @@ export class ZenodeEngine {
 
   gridToggles(toggle: boolean) {
     toggleGrid(toggle);
+  }
+
+  private resolvePortCoordinate(nodeId: string, portId: string): { x: number, y: number } | null {
+    if (nodeId.startsWith("vgroup-")) {
+      const ports = this.getGroupPorts(nodeId);
+      return ports?.[portId] || null;
+    } else {
+      const node = this.placedNodes.find(n => n.id === nodeId);
+      if (!node) return null;
+      const style = this.getShapeStyle(node);
+      if (!style) return { x: node.x, y: node.y };
+
+      const renderer = this.shapeRegistry.get(node.type);
+      const resolved = buildResolvedShapeConfig(node, style);
+      const ports = renderer.getPorts(resolved);
+      const port = ports[portId] || ports.center || { x: 0, y: 0 };
+
+      // Calculate rotated port position relative to node center
+      const rotation = (node.rotation || 0) * (Math.PI / 180);
+      const cos = Math.cos(rotation);
+      const sin = Math.sin(rotation);
+
+      const rotatedX = port.x * cos - port.y * sin;
+      const rotatedY = port.x * sin + port.y * cos;
+
+      return { x: node.x + rotatedX, y: node.y + rotatedY };
+    }
+  }
+
+  private calculateEdgeWaypoints(c: import("../connections/render.js").StoredConnection): { x: number, y: number }[] {
+    const source = this.resolvePortCoordinate(c.sourceNodeId, c.sourcePortId);
+    const target = this.resolvePortCoordinate(c.targetNodeId, c.targetPortId);
+    
+    if (!source || !target) return [];
+    
+    // For now, return start and end as baseline. 
+    // High-fidelity routing capture would require hooks into SmartRouter path calculation.
+    return [source, target];
   }
 
   private bindSelectionInteractions(): void {

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -3,9 +3,9 @@
   "version": "3.5.10",
   "description": "Pure state transformations and export functions for Zenode",
   "type": "module",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -13,19 +13,22 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
-    "dev": "rollup -c -w"
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@zenode/core": "workspace:*"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^28.0.3",
-    "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "rollup": "^4.37.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "vitest": "^3.0.0"
   },
   "author": "Manu Martin",
   "license": "Zenode License, MIT",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -25,6 +25,8 @@
     "@zenode/core": "workspace:*"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^28.0.3",
+    "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "rollup": "^4.37.0",
     "typescript": "^5.8.2",

--- a/packages/serializer/src/core/validator.ts
+++ b/packages/serializer/src/core/validator.ts
@@ -1,0 +1,46 @@
+import type { ZenodeDiagramState } from "@zenode/core";
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validates the integrity of a ZenodeDiagramState.
+ * Checks for versioning, required fields, and dangling connections.
+ */
+export function validateState(state: ZenodeDiagramState): ValidationResult {
+  const errors: string[] = [];
+
+  // 1. Version Check
+  if (!state.version) {
+    errors.push("State is missing mandatory 'version' field.");
+  } else if (state.version !== "1.0") {
+    errors.push(`Unsupported state version: ${state.version}. Expected "1.0".`);
+  }
+
+  // 2. Structural Requirements
+  if (!Array.isArray(state.nodes)) {
+    errors.push("Nodes property must be an array.");
+  }
+  if (!Array.isArray(state.edges)) {
+    errors.push("Edges property must be an array.");
+  }
+
+  // 3. ID Consistency & Dangling Edges
+  const nodeIds = new Set(state.nodes?.map((n) => n.id) || []);
+
+  state.edges?.forEach((edge, index) => {
+    if (!edge.sourceNodeId || !nodeIds.has(edge.sourceNodeId)) {
+      errors.push(`Edge[${index}] (${edge.id || 'unknown'}): sourceNodeId '${edge.sourceNodeId}' does not exist.`);
+    }
+    if (!edge.targetNodeId || !nodeIds.has(edge.targetNodeId)) {
+      errors.push(`Edge[${index}] (${edge.id || 'unknown'}): targetNodeId '${edge.targetNodeId}' does not exist.`);
+    }
+  });
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}

--- a/packages/serializer/src/formats/bpmn.ts
+++ b/packages/serializer/src/formats/bpmn.ts
@@ -1,0 +1,106 @@
+import type { ZenodeDiagramState, NodeData } from "@zenode/core";
+
+/**
+ * Maps Zenode shape types to BPMN 2.0 element types.
+ */
+function mapShapeToBPMN(node: NodeData): string {
+  const type = node.type.toLowerCase();
+  const meta = node.meta || {};
+
+  // Respect explicit BPMN type if stored in meta
+  if (meta.bpmnType) return meta.bpmnType as string;
+
+  switch (type) {
+    case 'circle':
+    case 'start':
+      return 'bpmn:StartEvent';
+    case 'end':
+      return 'bpmn:EndEvent';
+    case 'rhombus':
+    case 'decision':
+      return 'bpmn:ExclusiveGateway';
+    case 'rectangle':
+    case 'task':
+    default:
+      return 'bpmn:Task';
+  }
+}
+
+/**
+ * Extracts the human-readable label from a node.
+ */
+function getLabel(node: NodeData): string {
+  if (node.content?.items) {
+    const textItem = node.content.items.find(item => item.kind === 'text');
+    if (textItem?.value) return textItem.value;
+  }
+  return node.id;
+}
+
+/**
+ * Converts ZenodeDiagramState to BPMN 2.0 XML string.
+ * Includes both semantic BPMN elements and bpmndi diagram layout coordinates.
+ */
+export function toBPMN(state: ZenodeDiagramState): string {
+  const processId = "ZenodeProcess1";
+  const planeId = "ZenodePlane1";
+
+  // --- Semantic Elements ---
+  const semanticNodes = state.nodes.map(node => {
+    const bpmnType = mapShapeToBPMN(node);
+    const name = getLabel(node);
+    return `    <${bpmnType} id="${node.id}" name="${name}" />`;
+  }).join('\n');
+
+  const semanticEdges = state.edges.map(edge => {
+    const name = edge.meta?.label ? ` name="${edge.meta.label}"` : '';
+    return `    <bpmn:sequenceFlow id="${edge.id}" sourceRef="${edge.sourceNodeId}" targetRef="${edge.targetNodeId}"${name} />`;
+  }).join('\n');
+
+  // --- Diagram Layout (bpmndi) ---
+  const diagramNodes = state.nodes.map(node => {
+    const w = node.width ?? 100;
+    const h = node.height ?? 80;
+    // Normalize: Zenode (Center) -> BPMN (Top-Left)
+    const normalizedX = node.x - w / 2;
+    const normalizedY = node.y - h / 2;
+    
+    return `      <bpmndi:BPMNShape id="${node.id}_di" bpmnElement="${node.id}">
+        <dc:Bounds x="${normalizedX}" y="${normalizedY}" width="${w}" height="${h}" />
+      </bpmndi:BPMNShape>`;
+  }).join('\n');
+
+  const diagramEdges = state.edges.map(edge => {
+    const waypoints = edge.waypoints?.map(wp => 
+      `        <di:waypoint x="${wp.x}" y="${wp.y}" />`
+    ).join('\n') || '';
+
+    return `      <bpmndi:BPMNEdge id="${edge.id}_di" bpmnElement="${edge.id}">
+${waypoints}
+      </bpmndi:BPMNEdge>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  targetNamespace="http://zenode.io/bpmn"
+  exporter="Zenode Serializer"
+  exporterVersion="${state.version}">
+
+  <bpmn:process id="${processId}" isExecutable="false">
+${semanticNodes}
+${semanticEdges}
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram1">
+    <bpmndi:BPMNPlane id="${planeId}" bpmnElement="${processId}">
+${diagramNodes}
+${diagramEdges}
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+
+</bpmn:definitions>`;
+}

--- a/packages/serializer/src/formats/json.ts
+++ b/packages/serializer/src/formats/json.ts
@@ -1,0 +1,40 @@
+import type { ZenodeDiagramState } from "@zenode/core";
+import { validateState } from "../core/validator.js";
+
+/**
+ * Serializes a ZenodeDiagramState to a formatted JSON string.
+ * Validates state integrity before serializing.
+ */
+export function toJSON(state: ZenodeDiagramState): string {
+  const result = validateState(state);
+  if (!result.valid) {
+    throw new Error(`[zenode/serializer] Invalid state:\n  - ${result.errors.join('\n  - ')}`);
+  }
+  return JSON.stringify(state, null, 2);
+}
+
+/**
+ * Parses a raw JSON string and restores a validated ZenodeDiagramState.
+ * Applies version migration if needed.
+ */
+export function fromJSON(json: string): ZenodeDiagramState {
+  let parsed: any;
+
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("[zenode/serializer] fromJSON: Invalid JSON string provided.");
+  }
+
+  // Migration shim: tolerate legacy states missing the version field
+  if (!parsed.version) {
+    parsed.version = "1.0";
+  }
+
+  const result = validateState(parsed as ZenodeDiagramState);
+  if (!result.valid) {
+    throw new Error(`[zenode/serializer] Parsed JSON failed validation:\n  - ${result.errors.join('\n  - ')}`);
+  }
+
+  return parsed as ZenodeDiagramState;
+}

--- a/packages/serializer/src/formats/mermaid.ts
+++ b/packages/serializer/src/formats/mermaid.ts
@@ -1,0 +1,74 @@
+import type { ZenodeDiagramState, NodeData } from "@zenode/core";
+
+/**
+ * Maps Zenode shape types to Mermaid.js flowchart shape symbols.
+ */
+function mapShapeToMermaid(type: string): [string, string] {
+  const t = type.toLowerCase();
+  switch (t) {
+    case 'rhombus':
+    case 'decision':
+      return ['{', '}']; // Decision
+    case 'circle':
+    case 'start':
+    case 'end':
+      return ['((', '))']; // Circle
+    case 'oval':
+    case 'pill':
+      return ['([', '])']; // Stadium
+    case 'hexagon':
+      return ['{{', '}}']; // Hexagon
+    case 'trapezoid':
+      return ['[/', '\\]']; // Trapezoid
+    case 'parallelogram':
+      return ['[/', '/]']; // Parallelogram
+    case 'step':
+    case 'database':
+      return ['[(', ')]']; // Cylinder
+    case 'triangle':
+      return ['>', ']']; // Asymmetric
+    case 'rectangle':
+    case 'task':
+    default:
+      return ['[', ']']; // Square
+  }
+}
+
+/**
+ * Extracts a readable label from NodeContent or Fallback ID.
+ */
+function getLabel(node: NodeData): string {
+  if (node.content && node.content.items.length > 0) {
+    const textItem = node.content.items.find(item => item.kind === 'text');
+    if (textItem && textItem.value) {
+      // Escape harmful characters for mermaid
+      return textItem.value.replace(/"/g, '&quot;');
+    }
+  }
+  return node.id;
+}
+
+/**
+ * Converts ZenodeDiagramState to Mermaid Flowchart syntax.
+ */
+export function toMermaid(state: ZenodeDiagramState): string {
+  // Allow diagram direction override via metadata, default to TD
+  const direction = state.nodes?.[0]?.meta?.diagramDirection || 'TD';
+  const lines: string[] = [`graph ${direction}`];
+
+  // 1. Process Nodes
+  state.nodes.forEach(node => {
+    const [start, end] = mapShapeToMermaid(node.type);
+    const label = getLabel(node);
+    lines.push(`    ${node.id}${start}"${label}"${end}`);
+  });
+
+  // 2. Process Edges
+  state.edges.forEach(edge => {
+    // If we have meta label on edge, we could use it here
+    const label = edge.meta?.label ? `|${edge.meta.label}| ` : '';
+    lines.push(`    ${edge.sourceNodeId} --> ${label}${edge.targetNodeId}`);
+  });
+
+  return lines.join('\n');
+}

--- a/packages/serializer/src/index.ts
+++ b/packages/serializer/src/index.ts
@@ -1,20 +1,36 @@
-import type { ZenodeDiagramState } from "@zenode/core";
-
 /**
- * Serializes the pure Zenode diagram state to a JSON string.
+ * @zenode/serializer — Public API
+ *
+ * Pure, framework-agnostic serialization layer for the Zenode ecosystem.
+ * Converts ZenodeDiagramState to/from external formats.
+ *
+ * @example
+ * import { toJSON, fromJSON, toMermaid, toBPMN } from '@zenode/serializer';
  */
-export function toJSON(state: ZenodeDiagramState): string {
-    return JSON.stringify(state, null, 2);
-}
 
-/**
- * Parses a JSON string to restore a Zenode diagram state.
- */
-export function fromJSON(json: string): ZenodeDiagramState {
-    const state = JSON.parse(json);
-    if (!state.version) {
-        // Handle migration from legacy states if needed in the future
-        state.version = "1.0";
-    }
-    return state as ZenodeDiagramState;
-}
+// --- Core ---
+export { validateState } from './core/validator.js';
+export type { ValidationResult } from './core/validator.js';
+
+// --- JSON Format ---
+export { toJSON, fromJSON } from './formats/json.js';
+
+// --- Mermaid Format ---
+export { toMermaid } from './formats/mermaid.js';
+
+// --- BPMN Format ---
+export { toBPMN } from './formats/bpmn.js';
+
+// --- Utilities ---
+export {
+  getRootNodes,
+  getLeafNodes,
+  getOrphanNodes,
+  getEdgesForNode,
+} from './utils/graph.js';
+
+export {
+  isZenodeDiagramState,
+  isValidNodeData,
+  isValidEdgeData,
+} from './utils/guards.js';

--- a/packages/serializer/src/utils/graph.ts
+++ b/packages/serializer/src/utils/graph.ts
@@ -1,0 +1,47 @@
+import type { ZenodeDiagramState, NodeData, EdgeData } from "@zenode/core";
+
+/**
+ * Returns the set of node IDs that have at least one outgoing edge.
+ */
+export function getSourceNodes(state: ZenodeDiagramState): Set<string> {
+  return new Set(state.edges.map(e => e.sourceNodeId));
+}
+
+/**
+ * Returns the set of node IDs that have at least one incoming edge.
+ */
+export function getTargetNodes(state: ZenodeDiagramState): Set<string> {
+  return new Set(state.edges.map(e => e.targetNodeId));
+}
+
+/**
+ * Returns all edges that are connected to a given node ID (in or out).
+ */
+export function getEdgesForNode(state: ZenodeDiagramState, nodeId: string): EdgeData[] {
+  return state.edges.filter(e => e.sourceNodeId === nodeId || e.targetNodeId === nodeId);
+}
+
+/**
+ * Returns nodes that have no incoming edges (entry points / roots).
+ */
+export function getRootNodes(state: ZenodeDiagramState): NodeData[] {
+  const targets = getTargetNodes(state);
+  return state.nodes.filter(n => !targets.has(n.id));
+}
+
+/**
+ * Returns nodes that have no outgoing edges (terminal / leaf nodes).
+ */
+export function getLeafNodes(state: ZenodeDiagramState): NodeData[] {
+  const sources = getSourceNodes(state);
+  return state.nodes.filter(n => !sources.has(n.id));
+}
+
+/**
+ * Returns nodes that are completely disconnected from the graph.
+ */
+export function getOrphanNodes(state: ZenodeDiagramState): NodeData[] {
+  const sources = getSourceNodes(state);
+  const targets = getTargetNodes(state);
+  return state.nodes.filter(n => !sources.has(n.id) && !targets.has(n.id));
+}

--- a/packages/serializer/src/utils/guards.ts
+++ b/packages/serializer/src/utils/guards.ts
@@ -1,0 +1,36 @@
+import type { ZenodeDiagramState } from "@zenode/core";
+
+/**
+ * Runtime type guard: checks if the value structurally matches a ZenodeDiagramState.
+ */
+export function isZenodeDiagramState(value: unknown): value is ZenodeDiagramState {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj['version'] === 'string' &&
+    Array.isArray(obj['nodes']) &&
+    Array.isArray(obj['edges'])
+  );
+}
+
+/**
+ * Checks that a node data object has the minimum required fields.
+ */
+export function isValidNodeData(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj['id'] === 'string' && typeof obj['type'] === 'string';
+}
+
+/**
+ * Checks that an edge data object has the minimum required fields.
+ */
+export function isValidEdgeData(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj['id'] === 'string' &&
+    typeof obj['sourceNodeId'] === 'string' &&
+    typeof obj['targetNodeId'] === 'string'
+  );
+}

--- a/packages/serializer/tests/serializer.test.ts
+++ b/packages/serializer/tests/serializer.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import type { ZenodeDiagramState } from '@zenode/core';
+import { validateState } from '../src/core/validator.js';
+import { toJSON, fromJSON } from '../src/formats/json.js';
+import { toMermaid } from '../src/formats/mermaid.js';
+import { toBPMN } from '../src/formats/bpmn.js';
+import { getRootNodes, getLeafNodes, getOrphanNodes } from '../src/utils/graph.js';
+import { isZenodeDiagramState } from '../src/utils/guards.js';
+
+// ------------------------------------------------------------------
+// Test Fixtures
+// ------------------------------------------------------------------
+
+const emptyState: ZenodeDiagramState = {
+  version: "1.0",
+  nodes: [],
+  edges: [],
+  viewport: { x: 0, y: 0, zoom: 1 },
+};
+
+const singleNodeState: ZenodeDiagramState = {
+  version: "1.0",
+  nodes: [{ id: 'n1', type: 'circle', shapeVariantId: 'circle1', x: 100, y: 100 }],
+  edges: [],
+  viewport: { x: 0, y: 0, zoom: 1 },
+};
+
+const fullWorkflowState: ZenodeDiagramState = {
+  version: "1.0",
+  nodes: [
+    { id: 'start', type: 'circle', shapeVariantId: 'circle1', x: 100, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Start' }] } },
+    { id: 'process', type: 'rectangle', shapeVariantId: 'rect1', x: 300, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Process Data' }] } },
+    { id: 'decision', type: 'rhombus', shapeVariantId: 'rhombus1', x: 500, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Decision?' }] } },
+    { id: 'end', type: 'circle', shapeVariantId: 'circle1', x: 700, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'End' }] } },
+  ],
+  edges: [
+    { id: 'e1', sourceNodeId: 'start', sourcePortId: 'right', targetNodeId: 'process', targetPortId: 'left' },
+    { id: 'e2', sourceNodeId: 'process', sourcePortId: 'right', targetNodeId: 'decision', targetPortId: 'left' },
+    { id: 'e3', sourceNodeId: 'decision', sourcePortId: 'right', targetNodeId: 'end', targetPortId: 'left', meta: { label: 'Yes' } },
+  ],
+  viewport: { x: 0, y: 0, zoom: 1 },
+};
+
+// ------------------------------------------------------------------
+// 1. Validator Tests
+// ------------------------------------------------------------------
+
+describe('Validator', () => {
+  it('should pass for a valid full workflow state', () => {
+    const result = validateState(fullWorkflowState);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should pass for an empty graph', () => {
+    const result = validateState(emptyState);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should fail when version is missing', () => {
+    const bad = { ...emptyState, version: undefined as any };
+    const result = validateState(bad);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('version'))).toBe(true);
+  });
+
+  it('should fail when a dangling edge references a non-existent node', () => {
+    const danglingState: ZenodeDiagramState = {
+      ...singleNodeState,
+      edges: [{ id: 'e1', sourceNodeId: 'n1', sourcePortId: 'right', targetNodeId: 'GHOST_NODE', targetPortId: 'left' }],
+    };
+    const result = validateState(danglingState);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('GHOST_NODE'))).toBe(true);
+  });
+});
+
+// ------------------------------------------------------------------
+// 2. JSON Serialization Tests
+// ------------------------------------------------------------------
+
+describe('JSON Serializer', () => {
+  it('should serialize and deserialize without data loss', () => {
+    const jsonStr = toJSON(fullWorkflowState);
+    const restored = fromJSON(jsonStr);
+    expect(restored.nodes).toHaveLength(fullWorkflowState.nodes.length);
+    expect(restored.edges).toHaveLength(fullWorkflowState.edges.length);
+    expect(restored.version).toBe('1.0');
+  });
+
+  it('should produce valid JSON output', () => {
+    const jsonStr = toJSON(emptyState);
+    expect(() => JSON.parse(jsonStr)).not.toThrow();
+  });
+
+  it('should throw on invalid JSON input', () => {
+    expect(() => fromJSON('not { valid } json')).toThrow();
+  });
+
+  it('should throw on dangling edge during serialization', () => {
+    const invalid: ZenodeDiagramState = {
+      ...singleNodeState,
+      edges: [{ id: 'e1', sourceNodeId: 'n1', sourcePortId: 'right', targetNodeId: 'MISSING', targetPortId: 'left' }],
+    };
+    expect(() => toJSON(invalid)).toThrow(/Invalid state/);
+  });
+});
+
+// ------------------------------------------------------------------
+// 3. Mermaid Serialization Tests
+// ------------------------------------------------------------------
+
+describe('Mermaid Serializer', () => {
+  it('should produce a valid Mermaid header', () => {
+    const output = toMermaid(emptyState);
+    expect(output).toContain('graph TD');
+  });
+
+  it('should map nodes to Mermaid syntax', () => {
+    const output = toMermaid(fullWorkflowState);
+    expect(output).toContain('start');
+    expect(output).toContain('process');
+    expect(output).toContain('decision');
+  });
+
+  it('should use node labels from content', () => {
+    const output = toMermaid(fullWorkflowState);
+    expect(output).toContain('Start');
+    expect(output).toContain('Process Data');
+    expect(output).toContain('Decision?');
+  });
+
+  it('should include edge labels from meta', () => {
+    const output = toMermaid(fullWorkflowState);
+    expect(output).toContain('Yes');
+  });
+
+  it('should handle single-node graph', () => {
+    const output = toMermaid(singleNodeState);
+    expect(output).toContain('n1');
+    expect(output).not.toContain('-->');
+  });
+
+  it('should handle empty graph without errors', () => {
+    expect(() => toMermaid(emptyState)).not.toThrow();
+  });
+});
+
+// ------------------------------------------------------------------
+// 4. BPMN Serialization Tests
+// ------------------------------------------------------------------
+
+describe('BPMN Serializer', () => {
+  it('should produce valid XML with BPMN declarations', () => {
+    const output = toBPMN(fullWorkflowState);
+    expect(output).toContain('<?xml');
+    expect(output).toContain('bpmn:definitions');
+    expect(output).toContain('bpmn:process');
+  });
+
+  it('should map rhombus to ExclusiveGateway', () => {
+    const output = toBPMN(fullWorkflowState);
+    expect(output).toContain('bpmn:ExclusiveGateway');
+  });
+
+  it('should map rectangle to Task', () => {
+    const output = toBPMN(fullWorkflowState);
+    expect(output).toContain('bpmn:Task');
+  });
+
+  it('should include bpmndi layout with coordinates', () => {
+    const output = toBPMN(fullWorkflowState);
+    expect(output).toContain('bpmndi:BPMNShape');
+    expect(output).toContain('dc:Bounds');
+  });
+
+  it('should handle empty graph without errors', () => {
+    expect(() => toBPMN(emptyState)).not.toThrow();
+  });
+});
+
+// ------------------------------------------------------------------
+// 5. Graph Utility Tests
+// ------------------------------------------------------------------
+
+describe('Graph Utilities', () => {
+  it('getRootNodes should return the entry node (start)', () => {
+    const roots = getRootNodes(fullWorkflowState);
+    expect(roots.map(n => n.id)).toContain('start');
+  });
+
+  it('getLeafNodes should return the terminal node (end)', () => {
+    const leaves = getLeafNodes(fullWorkflowState);
+    expect(leaves.map(n => n.id)).toContain('end');
+  });
+
+  it('getOrphanNodes should return zero for a fully connected graph', () => {
+    const orphans = getOrphanNodes(fullWorkflowState);
+    expect(orphans).toHaveLength(0);
+  });
+
+  it('getOrphanNodes should detect a disconnected node', () => {
+    const stateWithOrphan: ZenodeDiagramState = {
+      ...fullWorkflowState,
+      nodes: [...fullWorkflowState.nodes, { id: 'orphan1', type: 'rectangle', shapeVariantId: 'rect1', x: 0, y: 0 }],
+    };
+    const orphans = getOrphanNodes(stateWithOrphan);
+    expect(orphans.map(n => n.id)).toContain('orphan1');
+  });
+});
+
+// ------------------------------------------------------------------
+// 6. Type Guards Tests
+// ------------------------------------------------------------------
+
+describe('Type Guards', () => {
+  it('isZenodeDiagramState should return true for valid state', () => {
+    expect(isZenodeDiagramState(fullWorkflowState)).toBe(true);
+  });
+
+  it('isZenodeDiagramState should return false for null', () => {
+    expect(isZenodeDiagramState(null)).toBe(false);
+  });
+
+  it('isZenodeDiagramState should return false for missing nodes array', () => {
+    expect(isZenodeDiagramState({ version: '1.0', edges: [] })).toBe(false);
+  });
+});

--- a/packages/serializer/tsconfig.json
+++ b/packages/serializer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "./",
     "module": "ESNext",
     "target": "ES6",
     "declaration": true,

--- a/packages/serializer/visualizer.html
+++ b/packages/serializer/visualizer.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zenode Serializer Playground</title>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <style>
+        :root {
+            --bg: #0f172a;
+            --card-bg: rgba(30, 41, 59, 0.7);
+            --accent: #38bdf8;
+            --text: #f8fafc;
+            --text-muted: #94a3b8;
+            --border: rgba(255, 255, 255, 0.1);
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            background-color: var(--bg);
+            color: var(--text);
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            overflow: hidden;
+            background-image: 
+                radial-gradient(at 0% 0%, rgba(56, 189, 248, 0.15) 0px, transparent 50%),
+                radial-gradient(at 100% 0%, rgba(139, 92, 246, 0.15) 0px, transparent 50%);
+        }
+
+        header {
+            padding: 1.5rem 2rem;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            backdrop-filter: blur(10px);
+        }
+
+        .logo {
+            font-size: 1.5rem;
+            font-weight: 800;
+            letter-spacing: -0.025em;
+            background: linear-gradient(to right, #38bdf8, #818cf8);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        main {
+            display: grid;
+            grid-template-columns: 450px 1fr;
+            flex: 1;
+            overflow: hidden;
+        }
+
+        .editor-pane {
+            border-right: 1px solid var(--border);
+            display: flex;
+            flex-direction: column;
+            background: rgba(15, 23, 42, 0.5);
+        }
+
+        .pane-header {
+            padding: 0.75rem 1.25rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        textarea {
+            flex: 1;
+            background: transparent;
+            border: none;
+            color: #e2e8f0;
+            padding: 1.5rem;
+            font-family: 'Fira Code', monospace;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            resize: none;
+            outline: none;
+        }
+
+        .preview-pane {
+            display: grid;
+            grid-template-rows: 1fr 1fr;
+            overflow: hidden;
+        }
+
+        .preview-box {
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .preview-content {
+            flex: 1;
+            overflow: auto;
+            padding: 2rem;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: rgba(0, 0, 0, 0.2);
+        }
+
+        .xml-content {
+            justify-content: flex-start;
+            align-items: flex-start;
+            padding: 1rem;
+        }
+
+        pre {
+            margin: 0;
+            color: #818cf8;
+            font-family: 'Fira Code', monospace;
+            font-size: 0.85rem;
+        }
+
+        button {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            color: var(--text);
+            padding: 0.4rem 0.8rem;
+            border-radius: 6px;
+            font-size: 0.75rem;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        button:hover {
+            background: var(--accent);
+            color: var(--bg);
+            border-color: var(--accent);
+        }
+
+        .error-toast {
+            position: fixed;
+            bottom: 2rem;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #ef4444;
+            color: white;
+            padding: 0.75rem 1.5rem;
+            border-radius: 8px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+            display: none;
+        }
+
+        #mermaid-output svg {
+            max-width: 100%;
+            height: auto;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="logo">ZENODE SERIALIZER</div>
+        <div style="display: flex; gap: 0.5rem;">
+            <button onclick="loadSample('workflow')">Full Workflow</button>
+            <button onclick="loadSample('empty')">Empty State</button>
+        </div>
+    </header>
+
+    <main>
+        <div class="editor-pane">
+            <div class="pane-header">Input JSON (Zenode State)</div>
+            <textarea id="json-input" spellcheck="false"></textarea>
+        </div>
+
+        <div class="preview-pane">
+            <div class="preview-box">
+                <div class="pane-header">Mermaid Visualization</div>
+                <div class="preview-content" id="mermaid-output"></div>
+            </div>
+            <div class="preview-box">
+                <div class="pane-header">BPMN 2.0 XML</div>
+                <div class="preview-content xml-content">
+                    <pre id="bpmn-output"></pre>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <div id="error" class="error-toast"></div>
+
+    <script>
+        const samples = {
+            workflow: {
+                version: "1.0",
+                nodes: [
+                    { id: 'start', type: 'circle', x: 100, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Start' }] } },
+                    { id: 'process', type: 'rectangle', x: 300, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Process Data' }] } },
+                    { id: 'decision', type: 'rhombus', x: 500, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Approve?' }] } },
+                    { id: 'end', type: 'circle', x: 700, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'End' }] } },
+                ],
+                edges: [
+                    { id: 'e1', sourceNodeId: 'start', targetNodeId: 'process' },
+                    { id: 'e2', sourceNodeId: 'process', targetNodeId: 'decision' },
+                    { id: 'e3', sourceNodeId: 'decision', targetNodeId: 'end', meta: { label: 'Yes' } },
+                ],
+                viewport: { x: 0, y: 0, zoom: 1 },
+            },
+            empty: {
+                version: "1.0",
+                nodes: [],
+                edges: [],
+                viewport: { x: 0, y: 0, zoom: 1 }
+            }
+        };
+
+        const input = document.getElementById('json-input');
+        const mermaidDiv = document.getElementById('mermaid-output');
+        const bpmnDiv = document.getElementById('bpmn-output');
+        const errorDiv = document.getElementById('error');
+
+        // Initial setup
+        mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+
+        input.addEventListener('input', update);
+
+        function loadSample(key) {
+            input.value = JSON.stringify(samples[key], null, 2);
+            update();
+        }
+
+        function showError(msg) {
+            errorDiv.textContent = msg;
+            errorDiv.style.display = msg ? 'block' : 'none';
+        }
+
+        /** Replicated Logic from Mermaid Format */
+        function toMermaid(state) {
+            const lines = ['graph TD'];
+            state.nodes.forEach(node => {
+                let s = '[', e = ']';
+                const type = node.type.toLowerCase();
+                if (type === 'circle') [s, e] = ['((', '))'];
+                if (type === 'rhombus' || type === 'decision') [s, e] = ['{', '}'];
+                
+                let label = node.id;
+                if (node.content?.items) {
+                    const textItem = node.content.items.find(i => i.kind === 'text');
+                    if (textItem) label = textItem.value;
+                }
+                lines.push(`    ${node.id}${s}"${label}"${e}`);
+            });
+            state.edges.forEach(edge => {
+                const label = edge.meta?.label ? `|${edge.meta.label}| ` : '';
+                lines.push(`    ${edge.sourceNodeId} --> ${label}${edge.targetNodeId}`);
+            });
+            return lines.join('\n');
+        }
+
+        /** Replicated Logic from BPMN Format */
+        function toBPMN(state) {
+            const nodes = state.nodes.map(node => {
+                let type = 'bpmn:Task';
+                if (node.type === 'circle') type = 'bpmn:StartEvent';
+                if (node.type === 'rhombus') type = 'bpmn:ExclusiveGateway';
+                return `    <${type} id="${node.id}" name="${node.id}" />`;
+            }).join('\n');
+
+            const edges = state.edges.map(edge => {
+                return `    <bpmn:sequenceFlow id="${edge.id}" sourceRef="${edge.sourceNodeId}" targetRef="${edge.targetNodeId}" />`;
+            }).join('\n');
+
+            return `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process1">
+${nodes}
+${edges}
+  </bpmn:process>
+</bpmn:definitions>`;
+        }
+
+        async function update() {
+            try {
+                const state = JSON.parse(input.value);
+                showError('');
+                
+                // 1. Mermaid
+                const mCode = toMermaid(state);
+                mermaidDiv.innerHTML = `<pre class="mermaid">${mCode}</pre>`;
+                await mermaid.run();
+
+                // 2. BPMN
+                bpmnDiv.textContent = toBPMN(state);
+
+            } catch (e) {
+                showError('Invalid JSON or State: ' + e.message);
+            }
+        }
+
+        loadSample('workflow');
+    </script>
+</body>
+</html>

--- a/packages/serializer/vitest.config.ts
+++ b/packages/serializer/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    // Turn off watch mode for CI runs
+    watch: false,
+  },
+});

--- a/playground/index.html
+++ b/playground/index.html
@@ -21,14 +21,6 @@
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%233b82f6'><path d='M12 2L2 12l10 10L22 12Z' /></svg>">
 
-    <!-- Preload Critical Dependencies for LCP -->
-    <link rel="modulepreload" href="./dist/designer/index.js" />
-    <link rel="modulepreload" href="./dist/serializer/index.js" />
-
-    <!-- Defer Heavy UI Scripts (TBT optimization) -->
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
-    <script src="https://unpkg.com/lucide@latest" defer></script>
-
     <script type="importmap">
     {
       "imports": {
@@ -36,6 +28,14 @@
       }
     }
     </script>
+
+    <!-- Preload Critical Dependencies for LCP -->
+    <link rel="modulepreload" href="./dist/designer/index.js" />
+    <link rel="modulepreload" href="./dist/serializer/index.js" />
+
+    <!-- Defer Heavy UI Scripts (TBT optimization) -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
+    <script src="https://unpkg.com/lucide@latest" defer></script>
     <style>
         :root {
             --bg-dark: #0f172a;
@@ -1309,8 +1309,16 @@
         <div id="canvasContainer"></div>
 
         <div class="toolbar">
+            <button class="tool-btn icon-only" onclick="window.open('./serializer/index.html', '_blank')"
+                title="Open Serializer Playground">
+                <i data-lucide="binary"></i>
+            </button>
+            <button class="tool-btn icon-only" onclick="toggleLiveState()"
+                title="Live Diagram State (getDiagramState)">
+                <i data-lucide="activity"></i>
+            </button>
             <button id="inspectorToggleBtn" class="tool-btn icon-only" onclick="toggleInspector()"
-                title="Live System State">
+                title="Live System Config">
                 <i data-lucide="terminal"></i>
             </button>
             <button id="settingsToggleBtn" class="tool-btn icon-only" onclick="toggleSettings()"
@@ -1460,11 +1468,35 @@
                         data-lucide="x"></i></button>
             </div>
         </div>
+
         <div class="json-container">
             <pre id="jsonPreview"></pre>
         </div>
     </div>
 
+    <!-- Live Diagram State Panel -->
+    <div id="liveStatePanel" class="sidebar" style="width: 500px;">
+        <div class="panel-header">
+            <div style="display: flex; align-items: center; gap: 8px;">
+                <div class="zenode-logo" style="width:20px; height:20px; border-radius:4px; margin-right:0;"></div>
+                <span style="color: #3b82f6;">Live Diagram State</span>
+                <span class="live-indicator">LIVE</span>
+            </div>
+            <div style="display: flex; gap: 10px;">
+                <button id="btnCopyLiveState" class="tool-btn" onclick="copyLiveState()"
+                    style="font-size: 11px; padding: 4px 12px; height: 32px; display: flex; align-items: center; gap: 6px;">
+                    <i data-lucide="copy" style="width:14px; height:14px;"></i> COPY JSON</button>
+                <button class="tool-btn icon-only" onclick="toggleLiveState()"
+                    style="border:none; background:transparent; width:36px; height:36px; color: var(--text-muted);"><i
+                        data-lucide="x"></i></button>
+            </div>
+        </div>
+
+        <div class="json-container">
+            <pre id="liveJsonPreview" style="color: #60a5fa;"></pre>
+        </div>
+    </div>
+    
     <script type="module">
         import * as Zenode from "./dist/designer/index.js";
         import * as Serializer from "./dist/serializer/index.js";
@@ -1478,32 +1510,7 @@
         let connOn = false;
 
         // --- UI Operations ---
-        function closeAll() {
-            document.getElementById('settingsPanel').classList.remove('active');
-            document.getElementById('inspectorPanel').classList.remove('active');
-            document.getElementById('contentPanel').classList.remove('active');
-            document.body.classList.remove('panel-open');
-        }
 
-        window.toggleSettings = () => {
-            const sp = document.getElementById('settingsPanel');
-            const isActive = sp.classList.contains('active');
-            closeAll();
-            if (!isActive) {
-                sp.classList.add('active');
-                document.body.classList.add('panel-open');
-            }
-        }
-
-        window.toggleInspector = () => {
-            const ip = document.getElementById('inspectorPanel');
-            const isActive = ip.classList.contains('active');
-            closeAll();
-            if (!isActive) {
-                ip.classList.add('active');
-                document.body.classList.add('panel-open');
-            }
-        }
 
         window.toggleContentPanel = () => {
             const cp = document.getElementById('contentPanel');
@@ -1954,6 +1961,14 @@
                     overlay.classList.add('fade-out');
                 }
             }, 1500);
+
+            // Register Live Update Listeners for Diagram State Panel
+            const liveEvents = ['node:placed', 'node:deleted', 'node:updated', 'edge:created', 'connection:created', 'edge:deleted', 'zoom', 'workflow:load', 'workflow:clear', 'node:status:change'];
+            liveEvents.forEach(ev => {
+                Zenode.on(ev, () => {
+                    updateLiveState();
+                });
+            });
         }
 
         let activeConnType = 'straight';
@@ -2206,6 +2221,67 @@
             const formRoot = document.getElementById('formContainer');
             if (formRoot) renderForm(currentConfig, formRoot);
             updatePreview();
+        };
+
+        window.toggleSettings = () => {
+            const sp = document.getElementById('settingsPanel');
+            const isActive = sp.classList.contains('active');
+            closeAll();
+            if (!isActive) {
+                sp.classList.add('active');
+                document.body.classList.add('panel-open');
+            }
+        }
+
+        window.toggleInspector = () => {
+            const ip = document.getElementById('inspectorPanel');
+            const isActive = ip.classList.contains('active');
+            closeAll();
+            if (!isActive) {
+                ip.classList.add('active');
+                document.body.classList.add('panel-open');
+                updatePreview();
+            }
+        }
+
+        window.toggleLiveState = () => {
+            const lp = document.getElementById('liveStatePanel');
+            const isActive = lp.classList.contains('active');
+            closeAll();
+            if (!isActive) {
+                lp.classList.add('active');
+                document.body.classList.add('panel-open');
+                updateLiveState();
+            }
+        }
+
+        function updateLiveState() {
+            const pre = document.getElementById('liveJsonPreview');
+            if (pre && document.getElementById('liveStatePanel').classList.contains('active')) {
+                const state = Zenode.getDiagramState();
+                pre.textContent = JSON.stringify(state, null, 2);
+            }
+        }
+
+        function closeAll() {
+            document.getElementById('settingsPanel').classList.remove('active');
+            document.getElementById('inspectorPanel').classList.remove('active');
+            document.getElementById('liveStatePanel').classList.remove('active');
+            document.getElementById('contentPanel').classList.remove('active');
+            document.body.classList.remove('panel-open');
+        }
+
+        window.copyLiveState = () => {
+            const content = document.getElementById('liveJsonPreview').textContent;
+            navigator.clipboard.writeText(content);
+            const btn = document.getElementById('btnCopyLiveState');
+            const original = btn.innerHTML;
+            btn.innerHTML = `<i data-lucide="check" style="width:14px; height:14px;"></i> COPIED!`;
+            lucide.createIcons();
+            setTimeout(() => {
+                btn.innerHTML = original;
+                lucide.createIcons();
+            }, 2000);
         };
 
         window.copyConfig = () => {

--- a/playground/serializer/index.html
+++ b/playground/serializer/index.html
@@ -1,0 +1,600 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zenode | Serializer Playground</title>
+    <!-- Same fonts as base -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+    
+    <link rel="stylesheet" href="../zenode.css">
+    
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%233b82f6'><path d='M12 2L2 12l10 10L22 12Z' /></svg>">
+    
+    <script src="https://unpkg.com/lucide@latest"></script>
+
+    <style>
+        :root {
+            --bg-dark: #0f172a;
+            --panel-bg: #1e293b;
+            --border: #334155;
+            --accent: #3b82f6;
+            --accent-glow: rgba(59, 130, 246, 0.4);
+            --text-main: #f1f5f9;
+            --text-muted: #94a3b8;
+            --error: #ef4444;
+            --success: #22c55e;
+        }
+
+        body {
+            background: var(--bg-dark);
+            color: var(--text-main);
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        /* Re-use Header Style */
+        .header-bar {
+            padding: 16px 32px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background: rgba(30, 41, 59, 0.8);
+            backdrop-filter: blur(16px);
+            border-bottom: 1px solid var(--border);
+            z-index: 100;
+        }
+
+        .zenode-logo {
+            width: 32px;
+            height: 32px;
+            background: linear-gradient(135deg, var(--accent), #8b5cf6);
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: 0 0 20px var(--accent-glow);
+            margin-right: 12px;
+        }
+
+        .zenode-logo::after {
+            content: "Z";
+            color: white;
+            font-weight: 900;
+            font-size: 18px;
+        }
+
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-name {
+            font-weight: 800;
+            font-size: 14px;
+            letter-spacing: 0.5px;
+        }
+
+        .brand-sub {
+            font-size: 10px;
+            color: var(--text-muted);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        /* 3-Column Layout */
+        main {
+            flex: 1;
+            display: grid;
+            grid-template-columns: 1fr 240px 1fr;
+            overflow: hidden;
+            background: #0d1117;
+        }
+
+        .column {
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            border-right: 1px solid var(--border);
+        }
+
+        .column:last-child {
+            border-right: none;
+        }
+
+        .column-header {
+            padding: 12px 20px;
+            background: rgba(30, 41, 59, 0.5);
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .column-title {
+            font-size: 11px;
+            font-weight: 800;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            color: var(--text-muted);
+        }
+
+        .format-selector {
+            background: rgba(15, 23, 42, 0.8);
+            border: 1px solid var(--border);
+            color: var(--text-main);
+            font-size: 11px;
+            padding: 4px 8px;
+            border-radius: 6px;
+            outline: none;
+            cursor: pointer;
+            appearance: none;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%2394a3b8'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 8px center;
+            background-size: 10px;
+            padding-right: 24px;
+        }
+
+        .format-selector option {
+            background: var(--bg-dark);
+            color: var(--text-main);
+        }
+
+        /* Editor Styles */
+        .editor-container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            position: relative;
+        }
+
+        textarea {
+            flex: 1;
+            background: transparent;
+            border: none;
+            color: #d1d5db;
+            padding: 20px;
+            font-family: 'Fira Code', monospace;
+            font-size: 13px;
+            line-height: 1.6;
+            resize: none;
+            outline: none;
+            tab-size: 2;
+        }
+
+        textarea::placeholder {
+            color: #4b5563;
+        }
+
+        .read-only {
+            background: rgba(0, 0, 0, 0.1);
+        }
+
+        /* Controls Column */
+        .controls-column {
+            background: var(--panel-bg);
+            padding: 24px 16px;
+            gap: 12px;
+            display: flex;
+            flex-direction: column;
+            overflow-y: auto;
+        }
+
+        .control-group {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-bottom: 16px;
+        }
+
+        .group-label {
+            font-size: 10px;
+            font-weight: 700;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 4px;
+        }
+
+        .btn {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 14px;
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            color: var(--text-main);
+            font-size: 12px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .btn:hover {
+            background: rgba(59, 130, 246, 0.1);
+            border-color: var(--accent);
+            transform: translateY(-1px);
+        }
+
+        .btn:active {
+            transform: translateY(0);
+        }
+
+        .btn i {
+            width: 16px;
+            height: 16px;
+            color: var(--text-muted);
+        }
+
+        .btn-primary {
+            background: var(--accent);
+            border-color: #60a5fa;
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: #2563eb;
+            box-shadow: 0 0 15px var(--accent-glow);
+        }
+
+        .btn-primary i {
+            color: white;
+        }
+
+        .btn-roundtrip {
+            border-color: #818cf8;
+            color: #818cf8;
+        }
+
+        .btn-roundtrip:hover {
+            background: rgba(129, 140, 248, 0.1);
+        }
+
+        /* Error/Status Panel */
+        .status-panel {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            padding: 12px 20px;
+            background: rgba(15, 23, 42, 0.9);
+            backdrop-filter: blur(8px);
+            border-top: 1px solid var(--border);
+            font-size: 12px;
+            max-height: 150px;
+            overflow-y: auto;
+            display: none;
+        }
+
+        .status-panel.active {
+            display: block;
+        }
+
+        .error-msg {
+            color: var(--error);
+            font-family: inherit;
+            white-space: pre-wrap;
+        }
+
+        .success-msg {
+            color: var(--success);
+            font-weight: 600;
+        }
+
+        /* Sample Dropdown Customization */
+        select.btn option {
+            background: var(--bg-dark);
+            color: var(--text-main);
+        }
+
+        .toolbar-right {
+            display: flex;
+            gap: 12px;
+        }
+
+        .action-link {
+            font-size: 12px;
+            color: var(--text-muted);
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            transition: color 0.2s;
+        }
+
+        .action-link:hover {
+            color: var(--text-main);
+        }
+    </style>
+</head>
+<body>
+    <header class="header-bar">
+        <div style="display: flex; align-items: center;">
+            <div class="zenode-logo"></div>
+            <div class="brand-text">
+                <span class="brand-name">Zenode</span>
+                <span class="brand-sub">Serializer Playground</span>
+            </div>
+        </div>
+        <div class="toolbar-right">
+            <a href="../index.html" class="action-link">
+                <i data-lucide="layout"></i>
+                Back to Designer
+            </a>
+            <button class="btn" style="padding: 6px 10px;" id="copyOutput">
+                <i data-lucide="copy"></i>
+                Copy Output
+            </button>
+        </div>
+    </header>
+
+    <main>
+        <!-- INPUT COLUMN -->
+        <section class="column">
+            <div class="column-header">
+                <span class="column-title">Input</span>
+                <select class="format-selector" id="inputFormat">
+                    <option value="json">JSON (Zenode)</option>
+                    <option value="mermaid" disabled>Mermaid (Coming Soon)</option>
+                    <option value="bpmn" disabled>BPMN (Coming Soon)</option>
+                </select>
+            </div>
+            <div class="editor-container">
+                <textarea id="inputEditor" spellcheck="false" placeholder="Paste your data here..."></textarea>
+                <div id="inputStatus" class="status-panel"></div>
+            </div>
+        </section>
+
+        <!-- CONTROLS COLUMN -->
+        <section class="controls-column">
+            <div class="control-group">
+                <span class="group-label">Load Samples</span>
+                <select class="btn" id="sampleLoader">
+                    <option value="" disabled selected>Choose a sample...</option>
+                    <option value="simple">Simple Flow</option>
+                    <option value="branching">Branching Workflow</option>
+                    <option value="cyclic">Loop / Cyclic Graph</option>
+                    <option value="metadata">Graph with Metadata</option>
+                    <option value="invalid">Invalid Graph (Test Errors)</option>
+                </select>
+            </div>
+
+            <div class="control-group">
+                <span class="group-label">Convert To</span>
+                <button class="btn btn-primary" id="btnToJson">
+                    <i data-lucide="code"></i>
+                    Zenode JSON
+                </button>
+                <button class="btn" id="btnToMermaid">
+                    <i data-lucide="file-text"></i>
+                    Mermaid Syntax
+                </button>
+                <button class="btn" id="btnToBpmn">
+                    <i data-lucide="share-2"></i>
+                    BPMN 2.0 XML
+                </button>
+            </div>
+
+            <div class="control-group">
+                <span class="group-label">Round-Trip Test</span>
+                <button class="btn btn-roundtrip" id="btnRtMermaid">
+                    <i data-lucide="refresh-cw"></i>
+                    JSON → Mermaid → JSON
+                </button>
+                <button class="btn btn-roundtrip" id="btnRtBpmn">
+                    <i data-lucide="refresh-cw"></i>
+                    JSON → BPMN → JSON
+                </button>
+            </div>
+
+            <div class="control-group" style="margin-top: auto;">
+                <button class="btn" id="btnClear" style="color: var(--error); border-color: rgba(239, 68, 68, 0.2);">
+                    <i data-lucide="trash-2"></i>
+                    Clear All
+                </button>
+            </div>
+        </section>
+
+        <!-- OUTPUT COLUMN -->
+        <section class="column">
+            <div class="column-header">
+                <span class="column-title">Output</span>
+                <span id="outputFormatLabel" style="font-size: 10px; color: var(--accent); font-weight: 700; text-transform: uppercase;">None</span>
+            </div>
+            <div class="editor-container">
+                <textarea id="outputEditor" class="read-only" readonly spellcheck="false" placeholder="Output will appear here..."></textarea>
+                <div id="outputStatus" class="status-panel"></div>
+            </div>
+        </section>
+    </main>
+
+    <script type="module">
+        import { 
+            toJSON, fromJSON, toMermaid, toBPMN, validateState 
+        } from '../dist/serializer/index.js';
+
+        // --- UI Elements ---
+        const inputEditor = document.getElementById('inputEditor');
+        const outputEditor = document.getElementById('outputEditor');
+        const inputFormat = document.getElementById('inputFormat');
+        const sampleLoader = document.getElementById('sampleLoader');
+        const inputStatus = document.getElementById('inputStatus');
+        const outputStatus = document.getElementById('outputStatus');
+        const outputLabel = document.getElementById('outputFormatLabel');
+
+        // --- State ---
+        const samples = {
+            simple: {
+                version: "1.0",
+                nodes: [
+                    { id: 'start', type: 'circle', x: 100, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Start' }] } },
+                    { id: 'end', type: 'circle', x: 400, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'End' }] } }
+                ],
+                edges: [{ id: 'e1', sourceNodeId: 'start', targetNodeId: 'end' }],
+                viewport: { x: 0, y: 0, zoom: 1 }
+            },
+            branching: {
+                version: "1.0",
+                nodes: [
+                    { id: 'n1', type: 'circle', x: 100, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Trigger' }] } },
+                    { id: 'n2', type: 'rhombus', x: 300, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Approved?' }] } },
+                    { id: 'n3', type: 'rectangle', x: 500, y: 50, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Process Success' }] } },
+                    { id: 'n4', type: 'rectangle', x: 500, y: 150, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Handle Rejection' }] } }
+                ],
+                edges: [
+                    { id: 'e1', sourceNodeId: 'n1', targetNodeId: 'n2' },
+                    { id: 'e2', sourceNodeId: 'n2', targetNodeId: 'n3', meta: { label: 'Yes' } },
+                    { id: 'e3', sourceNodeId: 'n2', targetNodeId: 'n4', meta: { label: 'No' } }
+                ],
+                viewport: { x: 0, y: 0, zoom: 1 }
+            },
+            cyclic: {
+                version: "1.0",
+                nodes: [
+                    { id: 'a', type: 'rectangle', x: 100, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Node A' }] } },
+                    { id: 'b', type: 'rectangle', x: 300, y: 100, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Node B' }] } }
+                ],
+                edges: [
+                    { id: 'e1', sourceNodeId: 'a', targetNodeId: 'b' },
+                    { id: 'e2', sourceNodeId: 'b', targetNodeId: 'a', meta: { label: 'Retry' } }
+                ],
+                viewport: { x: 0, y: 0, zoom: 1 }
+            },
+            metadata: {
+                version: "1.0",
+                nodes: [
+                    { id: 'm1', type: 'rectangle', x: 100, y: 100, meta: { customAttr: 'val' }, content: { layout: 'text-only', items: [{ kind: 'text', value: 'Custom Data' }] } }
+                ],
+                edges: [],
+                viewport: { x: 10, y: 20, zoom: 0.8 }
+            },
+            invalid: {
+                version: "1.0",
+                nodes: [{ id: 'n1', type: 'circle', x: 100, y: 100 }],
+                edges: [{ id: 'e1', sourceNodeId: 'n1', targetNodeId: 'GHOST_NODE' }],
+                viewport: { x: 0, y: 0, zoom: 1 }
+            }
+        };
+
+        // --- Helpers ---
+        function setStatus(panel, html, isError = false) {
+            panel.innerHTML = html;
+            panel.className = `status-panel active ${isError ? 'error' : ''}`;
+            if (!html) panel.classList.remove('active');
+        }
+
+        function clearStatues() {
+            setStatus(inputStatus, '');
+            setStatus(outputStatus, '');
+        }
+
+        // --- Actions ---
+        function runConversion(target) {
+            clearStatues();
+            const raw = inputEditor.value.trim();
+            if (!raw) return;
+
+            try {
+                let state;
+                if (inputFormat.value === 'json') {
+                    state = fromJSON(raw);
+                } else {
+                    throw new Error(`Reverse parsing (from ${inputFormat.value.toUpperCase()}) is currently a 'Layer 3' roadmap item and not yet available in the pure-function core library.`);
+                }
+
+                let output = '';
+                switch(target) {
+                    case 'json': 
+                        output = toJSON(state); 
+                        outputLabel.textContent = 'JSON';
+                        break;
+                    case 'mermaid': 
+                        output = toMermaid(state); 
+                        outputLabel.textContent = 'Mermaid';
+                        break;
+                    case 'bpmn': 
+                        output = toBPMN(state); 
+                        outputLabel.textContent = 'BPMN 2.0';
+                        break;
+                }
+
+                outputEditor.value = output;
+                setStatus(outputStatus, `<span class="success-msg">Successfully converted to ${target.toUpperCase()}</span>`);
+            } catch (e) {
+                setStatus(inputStatus, `<div class="error-msg">${e.message}</div>`, true);
+            }
+        }
+
+        // --- Event Listeners ---
+        sampleLoader.addEventListener('change', () => {
+            const key = sampleLoader.value;
+            if (samples[key]) {
+                inputFormat.value = 'json';
+                inputEditor.value = JSON.stringify(samples[key], null, 2);
+                clearStatues();
+            }
+        });
+
+        document.getElementById('btnToJson').onclick = () => runConversion('json');
+        document.getElementById('btnToMermaid').onclick = () => runConversion('mermaid');
+        document.getElementById('btnToBpmn').onclick = () => runConversion('bpmn');
+
+        document.getElementById('btnClear').onclick = () => {
+            inputEditor.value = '';
+            outputEditor.value = '';
+            clearStatues();
+            outputLabel.textContent = 'None';
+        };
+
+        document.getElementById('copyOutput').onclick = () => {
+            navigator.clipboard.writeText(outputEditor.value);
+            const btn = document.getElementById('copyOutput');
+            const original = btn.innerHTML;
+            btn.innerHTML = `<i data-lucide="check"></i> Copied!`;
+            lucide.createIcons();
+            setTimeout(() => {
+                btn.innerHTML = original;
+                lucide.createIcons();
+            }, 2000);
+        };
+
+        document.getElementById('btnRtMermaid').onclick = () => {
+            clearStatues();
+            try {
+                const state = fromJSON(inputEditor.value);
+                const mermaid = toMermaid(state);
+                // In a real scenario we'd call fromMermaid here
+                // For now we just show the output and mention it
+                outputEditor.value = mermaid;
+                outputLabel.textContent = 'Mermaid (RT Part 1)';
+                setStatus(outputStatus, `<div class="error-msg">Round-trip incomplete: 'fromMermaid' is not yet available in the library.</div>`, true);
+            } catch (e) {
+                setStatus(inputStatus, `<div class="error-msg">${e.message}</div>`, true);
+            }
+        };
+
+        document.getElementById('btnRtBpmn').onclick = () => {
+            clearStatues();
+            try {
+                const state = fromJSON(inputEditor.value);
+                const bpmn = toBPMN(state);
+                outputEditor.value = bpmn;
+                outputLabel.textContent = 'BPMN (RT Part 1)';
+                setStatus(outputStatus, `<div class="error-msg">Round-trip incomplete: 'fromBPMN' is not yet available in the library.</div>`, true);
+            } catch (e) {
+                setStatus(inputStatus, `<div class="error-msg">${e.message}</div>`, true);
+            }
+        };
+
+        lucide.createIcons();
+    </script>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,12 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^28.0.3
+        version: 28.0.9(rollup@4.60.1)
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.1
+        version: 16.0.3(rollup@4.60.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.2
         version: 12.3.0(rollup@4.60.1)(tslib@2.8.1)(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,12 +64,6 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
-      '@rollup/plugin-commonjs':
-        specifier: ^28.0.3
-        version: 28.0.9(rollup@4.60.1)
-      '@rollup/plugin-node-resolve':
-        specifier: ^16.0.1
-        version: 16.0.3(rollup@4.60.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.2
         version: 12.3.0(rollup@4.60.1)(tslib@2.8.1)(typescript@5.9.3)
@@ -79,6 +73,9 @@ importers:
       typescript:
         specifier: ^5.8.2
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4
 
   packages/zenode:
     dependencies:
@@ -109,6 +106,162 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -291,6 +444,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -384,6 +540,9 @@ packages:
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -393,9 +552,42 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -403,6 +595,10 @@ packages:
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -412,9 +608,17 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -570,6 +774,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -589,15 +797,30 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -684,6 +907,12 @@ packages:
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -702,6 +931,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -713,6 +947,16 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -720,6 +964,10 @@ packages:
   portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
     engines: {node: '>= 10.12'}
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -769,6 +1017,22 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -776,6 +1040,28 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -792,12 +1078,168 @@ packages:
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
 snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -914,6 +1356,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -1032,21 +1479,69 @@ snapshots:
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/geojson@7946.0.16': {}
 
   '@types/resolve@1.20.2': {}
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2)':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  assertion-error@2.0.1: {}
 
   async@3.2.6: {}
 
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
+
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -1058,10 +1553,20 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -1231,6 +1736,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deepmerge@4.3.1: {}
 
   delaunator@5.1.0:
@@ -1247,13 +1754,50 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   eventemitter3@4.0.7: {}
+
+  expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -1343,6 +1887,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1355,11 +1903,19 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.11: {}
+
   object-inspect@1.13.4: {}
 
   opener@1.5.2: {}
 
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
 
@@ -1369,6 +1925,12 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   qs@6.15.0:
     dependencies:
@@ -1451,11 +2013,38 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tslib@2.8.1: {}
 
@@ -1467,6 +2056,82 @@ snapshots:
 
   url-join@4.0.1: {}
 
+  vite-node@3.2.4:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2:
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@3.2.4:
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2
+      vite-node: 3.2.4
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   whatwg-encoding@2.0.0:
     dependencies:
       iconv-lite: 0.6.3
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/public/index.html
+++ b/public/index.html
@@ -21,14 +21,6 @@
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%233b82f6'><path d='M12 2L2 12l10 10L22 12Z' /></svg>">
 
-    <!-- Preload Critical Dependencies for LCP -->
-    <link rel="modulepreload" href="./dist/designer/index.js" />
-    <link rel="modulepreload" href="./dist/serializer/index.js" />
-
-    <!-- Defer Heavy UI Scripts (TBT optimization) -->
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
-    <script src="https://unpkg.com/lucide@latest" defer></script>
-
     <script type="importmap">
     {
       "imports": {
@@ -36,6 +28,14 @@
       }
     }
     </script>
+
+    <!-- Preload Critical Dependencies for LCP -->
+    <link rel="modulepreload" href="./dist/designer/index.js" />
+    <link rel="modulepreload" href="./dist/serializer/index.js" />
+
+    <!-- Defer Heavy UI Scripts (TBT optimization) -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
+    <script src="https://unpkg.com/lucide@latest" defer></script>
     <style>
         :root {
             --bg-dark: #0f172a;
@@ -1309,8 +1309,16 @@
         <div id="canvasContainer"></div>
 
         <div class="toolbar">
+            <button class="tool-btn icon-only" onclick="window.open('./serializer/index.html', '_blank')"
+                title="Open Serializer Playground">
+                <i data-lucide="binary"></i>
+            </button>
+            <button class="tool-btn icon-only" onclick="toggleLiveState()"
+                title="Live Diagram State (getDiagramState)">
+                <i data-lucide="activity"></i>
+            </button>
             <button id="inspectorToggleBtn" class="tool-btn icon-only" onclick="toggleInspector()"
-                title="Live System State">
+                title="Live System Config">
                 <i data-lucide="terminal"></i>
             </button>
             <button id="settingsToggleBtn" class="tool-btn icon-only" onclick="toggleSettings()"
@@ -1460,11 +1468,35 @@
                         data-lucide="x"></i></button>
             </div>
         </div>
+
         <div class="json-container">
             <pre id="jsonPreview"></pre>
         </div>
     </div>
 
+    <!-- Live Diagram State Panel -->
+    <div id="liveStatePanel" class="sidebar" style="width: 500px;">
+        <div class="panel-header">
+            <div style="display: flex; align-items: center; gap: 8px;">
+                <div class="zenode-logo" style="width:20px; height:20px; border-radius:4px; margin-right:0;"></div>
+                <span style="color: #3b82f6;">Live Diagram State</span>
+                <span class="live-indicator">LIVE</span>
+            </div>
+            <div style="display: flex; gap: 10px;">
+                <button id="btnCopyLiveState" class="tool-btn" onclick="copyLiveState()"
+                    style="font-size: 11px; padding: 4px 12px; height: 32px; display: flex; align-items: center; gap: 6px;">
+                    <i data-lucide="copy" style="width:14px; height:14px;"></i> COPY JSON</button>
+                <button class="tool-btn icon-only" onclick="toggleLiveState()"
+                    style="border:none; background:transparent; width:36px; height:36px; color: var(--text-muted);"><i
+                        data-lucide="x"></i></button>
+            </div>
+        </div>
+
+        <div class="json-container">
+            <pre id="liveJsonPreview" style="color: #60a5fa;"></pre>
+        </div>
+    </div>
+    
     <script type="module">
         import * as Zenode from "./dist/designer/index.js";
         import * as Serializer from "./dist/serializer/index.js";
@@ -1478,32 +1510,7 @@
         let connOn = false;
 
         // --- UI Operations ---
-        function closeAll() {
-            document.getElementById('settingsPanel').classList.remove('active');
-            document.getElementById('inspectorPanel').classList.remove('active');
-            document.getElementById('contentPanel').classList.remove('active');
-            document.body.classList.remove('panel-open');
-        }
 
-        window.toggleSettings = () => {
-            const sp = document.getElementById('settingsPanel');
-            const isActive = sp.classList.contains('active');
-            closeAll();
-            if (!isActive) {
-                sp.classList.add('active');
-                document.body.classList.add('panel-open');
-            }
-        }
-
-        window.toggleInspector = () => {
-            const ip = document.getElementById('inspectorPanel');
-            const isActive = ip.classList.contains('active');
-            closeAll();
-            if (!isActive) {
-                ip.classList.add('active');
-                document.body.classList.add('panel-open');
-            }
-        }
 
         window.toggleContentPanel = () => {
             const cp = document.getElementById('contentPanel');
@@ -1954,6 +1961,14 @@
                     overlay.classList.add('fade-out');
                 }
             }, 1500);
+
+            // Register Live Update Listeners for Diagram State Panel
+            const liveEvents = ['node:placed', 'node:deleted', 'node:updated', 'edge:created', 'connection:created', 'edge:deleted', 'zoom', 'workflow:load', 'workflow:clear', 'node:status:change'];
+            liveEvents.forEach(ev => {
+                Zenode.on(ev, () => {
+                    updateLiveState();
+                });
+            });
         }
 
         let activeConnType = 'straight';
@@ -2206,6 +2221,67 @@
             const formRoot = document.getElementById('formContainer');
             if (formRoot) renderForm(currentConfig, formRoot);
             updatePreview();
+        };
+
+        window.toggleSettings = () => {
+            const sp = document.getElementById('settingsPanel');
+            const isActive = sp.classList.contains('active');
+            closeAll();
+            if (!isActive) {
+                sp.classList.add('active');
+                document.body.classList.add('panel-open');
+            }
+        }
+
+        window.toggleInspector = () => {
+            const ip = document.getElementById('inspectorPanel');
+            const isActive = ip.classList.contains('active');
+            closeAll();
+            if (!isActive) {
+                ip.classList.add('active');
+                document.body.classList.add('panel-open');
+                updatePreview();
+            }
+        }
+
+        window.toggleLiveState = () => {
+            const lp = document.getElementById('liveStatePanel');
+            const isActive = lp.classList.contains('active');
+            closeAll();
+            if (!isActive) {
+                lp.classList.add('active');
+                document.body.classList.add('panel-open');
+                updateLiveState();
+            }
+        }
+
+        function updateLiveState() {
+            const pre = document.getElementById('liveJsonPreview');
+            if (pre && document.getElementById('liveStatePanel').classList.contains('active')) {
+                const state = Zenode.getDiagramState();
+                pre.textContent = JSON.stringify(state, null, 2);
+            }
+        }
+
+        function closeAll() {
+            document.getElementById('settingsPanel').classList.remove('active');
+            document.getElementById('inspectorPanel').classList.remove('active');
+            document.getElementById('liveStatePanel').classList.remove('active');
+            document.getElementById('contentPanel').classList.remove('active');
+            document.body.classList.remove('panel-open');
+        }
+
+        window.copyLiveState = () => {
+            const content = document.getElementById('liveJsonPreview').textContent;
+            navigator.clipboard.writeText(content);
+            const btn = document.getElementById('btnCopyLiveState');
+            const original = btn.innerHTML;
+            btn.innerHTML = `<i data-lucide="check" style="width:14px; height:14px;"></i> COPIED!`;
+            lucide.createIcons();
+            setTimeout(() => {
+                btn.innerHTML = original;
+                lucide.createIcons();
+            }, 2000);
         };
 
         window.copyConfig = () => {

--- a/scripts/collect.js
+++ b/scripts/collect.js
@@ -9,7 +9,9 @@ const publicDir = path.join(root, 'public');
  */
 function copyFolderSync(from, to) {
     if (!fs.existsSync(from)) return;
-    if (!fs.existsSync(to)) fs.mkdirSync(to, { recursive: true });
+    if (!fs.existsSync(to)) {
+        fs.mkdirSync(to, { recursive: true });
+    }
     
     fs.readdirSync(from).forEach(element => {
         const fromPath = path.join(from, element);
@@ -45,5 +47,9 @@ if (fs.existsSync(path.join(root, 'playground/zenode.css'))) {
 console.log('[DEPLOY] Syncing package bundles...');
 copyFolderSync(path.join(root, 'packages/designer/dist'), path.join(publicDir, 'dist/designer'));
 copyFolderSync(path.join(root, 'packages/serializer/dist'), path.join(publicDir, 'dist/serializer'));
+
+// 3. Copy Serializer Playground
+console.log('[DEPLOY] Syncing serializer playground...');
+copyFolderSync(path.join(root, 'playground/serializer'), path.join(publicDir, 'serializer'));
 
 console.log('[DEPLOY] Done! All artifacts collected in public/');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "./",
     "module": "ESNext",
     "target": "ES6",
     "declaration": true,
@@ -38,7 +38,7 @@
     }
   },
   "include": [
-    "src",
+    "packages/**/src",
     "tests/**/*.ts",
     "src/typings"
   ]


### PR DESCRIPTION
Introduce a standalone @zenode/serializer package providing pure, framework-agnostic transformations for ZenodeDiagramState. Adds JSON, Mermaid and BPMN format modules (toJSON/fromJSON, toMermaid, toBPMN), a validator, graph utilities and runtime guards, plus Vitest tests and a vitest config. Exposes these from src/index and includes a visualizer/playground HTML. Package metadata updated (exports, files, test scripts, vitest devDep) and tsconfig rootDir adjusted. Also update core types to add edge waypoints/dashed/animated and enhance the designer engine to resolve port coordinates and compute basic edge waypoints; integrate serializer UI and a live diagram-state panel into the playground/public pages.